### PR TITLE
feat: add optional 'bc_id' parameter for Reporting API

### DIFF
--- a/java_sdk/src/main/java/io/swagger/client/api/ReportingApi.java
+++ b/java_sdk/src/main/java/io/swagger/client/api/ReportingApi.java
@@ -62,10 +62,11 @@ import java.util.Map;
    * @param page Current page number. Default value- &#x60;1&#x60; (optional)
    * @param pageSize Pagination size. Value range- 1-1000. Default value- &#x60;10&#x60;. (optional)
    * @param queryMode The way data is queried. Enum values- &#x60;REGULAR&#x60;, &#x60;CHUNK&#x60;. Default value- &#x60;REGULAR&#x60;.  With &#x60;CHUNK&#x60; mode on, data can be returned much faster in a more stable way. Meanwhile, pagination will not be working with &#x60;CHUNK&#x60;. (optional)
+   * @param bcId The business center ID. If not provided, the default business center ID for the account will be used. (optional)
    * @return InlineResponse200
    * @throws ApiException if fails to make API call
    */
-  public Response reportIntegratedGet(String advertiserId, String reportType, List<String> dimensions, String accessToken, String serviceType, String dataLevel, List<String> metrics, String orderField, String orderType, String startDate, String endDate, List<FilteringReportIntegratedGet> filtering, Boolean queryLifetime, Integer page, Integer pageSize, String queryMode) throws ApiException, SDKException, SDKExceptionForEvent {
+  public Response reportIntegratedGet(String advertiserId, String reportType, List<String> dimensions, String accessToken, String serviceType, String dataLevel, List<String> metrics, String orderField, String orderType, String startDate, String endDate, List<FilteringReportIntegratedGet> filtering, Boolean queryLifetime, Integer page, Integer pageSize, String queryMode, String bcId) throws ApiException, SDKException, SDKExceptionForEvent {
     Object localVarPostBody = null;
     // verify the required parameter 'advertiserId' is set
     if (advertiserId == null) {
@@ -106,6 +107,7 @@ import java.util.Map;
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "page", page));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "page_size", pageSize));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "query_mode", queryMode));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "bc_id", bcId));
 
     if (accessToken != null)
       localVarHeaderParams.put("Access-Token", apiClient.parameterToString(accessToken));

--- a/js_sdk/src/api/ReportingApi.js
+++ b/js_sdk/src/api/ReportingApi.js
@@ -54,6 +54,7 @@ export class ReportingApi {
      * @param {Number} opts.page Current page number. Default value- &#x60;1&#x60;
      * @param {Number} opts.page_size Pagination size. Value range- 1-1000. Default value- &#x60;10&#x60;.
      * @param {String} opts.query_mode The way data is queried. Enum values- &#x60;REGULAR&#x60;, &#x60;CHUNK&#x60;. Default value- &#x60;REGULAR&#x60;.  With &#x60;CHUNK&#x60; mode on, data can be returned much faster in a more stable way. Meanwhile, pagination will not be working with &#x60;CHUNK&#x60;.
+     * @param {string} opts.bc_id The business center ID. If not provided, the default business center ID for the account will be used. (optional)
      * @param {module:api/ReportingApi~reportIntegratedGetCallback} callback The callback function, accepting three arguments: error, data, response
      * data is of type: {@link <&vendorExtensions.x-jsdoc-type>}
      */
@@ -81,7 +82,7 @@ export class ReportingApi {
         
       };
       let queryParams = {
-        'advertiser_id': advertiser_id,'service_type': opts['service_type'],'data_level': opts['data_level'],'report_type': report_type,'dimensions': this.apiClient.buildCollectionParam(dimensions, 'multi'),'metrics': this.apiClient.buildCollectionParam(opts['metrics'], 'multi'),'order_field': opts['order_field'],'order_type': opts['order_type'],'start_date': opts['start_date'],'end_date': opts['end_date'],'filtering': this.apiClient.buildCollectionParam(opts['filtering'], 'multi'),'query_lifetime': opts['query_lifetime'],'page': opts['page'],'page_size': opts['page_size'],'query_mode': opts['query_mode']
+        'advertiser_id': advertiser_id,'service_type': opts['service_type'],'data_level': opts['data_level'],'report_type': report_type,'dimensions': this.apiClient.buildCollectionParam(dimensions, 'multi'),'metrics': this.apiClient.buildCollectionParam(opts['metrics'], 'multi'),'order_field': opts['order_field'],'order_type': opts['order_type'],'start_date': opts['start_date'],'end_date': opts['end_date'],'filtering': this.apiClient.buildCollectionParam(opts['filtering'], 'multi'),'query_lifetime': opts['query_lifetime'],'page': opts['page'],'page_size': opts['page_size'],'query_mode': opts['query_mode'], 'bc_id': opts['bc_id']
       };
       let headerParams = {
         'Access-Token': Access_Token

--- a/python_sdk/business_api_client/api/reporting_api.py
+++ b/python_sdk/business_api_client/api/reporting_api.py
@@ -53,6 +53,7 @@ class ReportingApi(object):
         :param int page: Current page number. Default value- `1`
         :param int page_size: Pagination size. Value range- 1-1000. Default value- `10`.
         :param str query_mode: The way data is queried. Enum values- `REGULAR`, `CHUNK`. Default value- `REGULAR`.  With `CHUNK` mode on, data can be returned much faster in a more stable way. Meanwhile, pagination will not be working with `CHUNK`.
+        :param str bc_id: The business center ID. If not provided, the default business center ID for the account will be used. (optional)
         :return: InlineResponse200
                  If the method is called asynchronously,
                  returns the request thread.
@@ -89,12 +90,13 @@ class ReportingApi(object):
         :param int page: Current page number. Default value- `1`
         :param int page_size: Pagination size. Value range- 1-1000. Default value- `10`.
         :param str query_mode: The way data is queried. Enum values- `REGULAR`, `CHUNK`. Default value- `REGULAR`.  With `CHUNK` mode on, data can be returned much faster in a more stable way. Meanwhile, pagination will not be working with `CHUNK`.
+        :param str bc_id: The business center ID. If not provided, the default business center ID for the account will be used. (optional)
         :return: InlineResponse200
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['advertiser_id', 'report_type', 'dimensions', 'access_token', 'service_type', 'data_level', 'metrics', 'order_field', 'order_type', 'start_date', 'end_date', 'filtering', 'query_lifetime', 'page', 'page_size', 'query_mode']  # noqa: E501
+        all_params = ['advertiser_id', 'report_type', 'dimensions', 'access_token', 'service_type', 'data_level', 'metrics', 'order_field', 'order_type', 'start_date', 'end_date', 'filtering', 'query_lifetime', 'page', 'page_size', 'query_mode', 'bc_id']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')


### PR DESCRIPTION
When the report_type is BC, the bc_id parameter is required, but the current implementation cannot add the bc_id, so this is a PR that addresses that issue.